### PR TITLE
Preserve timestamp milliseconds when serializing WireMessage (#1)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,6 +100,8 @@ extern crate libc;
 extern crate libflate;
 extern crate rand;
 extern crate serde;
+
+#[cfg_attr(test, macro_use)]
 extern crate serde_json;
 
 #[macro_use]

--- a/src/message/wire_message.rs
+++ b/src/message/wire_message.rs
@@ -96,8 +96,11 @@ impl<'a> serde::Serialize for WireMessage<'a> {
         }
 
         if self.message.timestamp().is_some() {
+            let datetime = &self.message.timestamp().unwrap();
+            let value = format!("{}.{}", datetime.timestamp(), datetime.timestamp_subsec_millis());
+
             map.serialize_key("timestamp")?;
-            map.serialize_value(&self.message.timestamp().unwrap().timestamp())?;
+            map.serialize_value(&value)?;
         }
 
         for (key, value) in self.message.all_metadata().iter() {


### PR DESCRIPTION
Hi!

This change makes it so milliseconds of chrono::DateTime are preserved when serializing it into a GELF timestamp.